### PR TITLE
switch from v1 cloud_sql_proxy to v2 cloud-sql-proxy

### DIFF
--- a/daktari/checks/google.py
+++ b/daktari/checks/google.py
@@ -46,7 +46,7 @@ class CloudSqlProxyInstalled(Check):
     def check(self) -> CheckResult:
         installed_version = get_simple_cli_version("cloud-sql-proxy")
         return self.validate_semver_expression(
-            "cloud_sql_proxy", installed_version, self.required_version, self.recommended_version
+            "cloud-sql-proxy", installed_version, self.required_version, self.recommended_version
         )
 
 

--- a/daktari/checks/google.py
+++ b/daktari/checks/google.py
@@ -40,11 +40,11 @@ class CloudSqlProxyInstalled(Check):
         self.recommended_version = recommended_version
 
     suggestions = {
-        OS.GENERIC: "Install Cloud SQL Proxy: <cmd>gcloud components install cloud_sql_proxy</cmd>",
+        OS.GENERIC: "Install Cloud SQL Proxy: <cmd>gcloud components install cloud-sql-proxy</cmd>",
     }
 
     def check(self) -> CheckResult:
-        installed_version = get_simple_cli_version("cloud_sql_proxy")
+        installed_version = get_simple_cli_version("cloud-sql-proxy")
         return self.validate_semver_expression(
             "cloud_sql_proxy", installed_version, self.required_version, self.recommended_version
         )


### PR DESCRIPTION
### **User description**
This one had me scratching my head for a while. If you install this with `gcloud components install cloud_sql_proxy` you get some version 1.X.X, and it will tell you it is up-to-date. Looks like they switched the naming to kebab casing when they went to version 2. All the help and checks work for me for versions 2.x.x after updating the check to expect kebab casing too


___

### **PR Type**
Enhancement


___

### **Description**
- Update Cloud SQL Proxy command from v1 to v2

- Switch from underscore to kebab-case naming convention

- Maintain version validation functionality


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["cloud_sql_proxy v1"] -- "upgrade" --> B["cloud-sql-proxy v2"]
  B --> C["Updated installation command"]
  B --> D["Updated version check"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>google.py</strong><dd><code>Update Cloud SQL Proxy to v2 naming</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

daktari/checks/google.py

<ul><li>Updated installation command from <code>cloud_sql_proxy</code> to <code>cloud-sql-proxy</code><br> <li> Changed CLI version check to use kebab-case naming<br> <li> Maintained existing version validation logic</ul>


</details>


  </td>
  <td><a href="https://github.com/genio-learn/daktari/pull/395/files#diff-f0bfe3824b2b48968d461c871a77aa0318b45195ccf1a5c898862f9f90ee8879">+2/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

